### PR TITLE
Cleanup StatusNotifier permissions

### DIFF
--- a/io.github.NhekoReborn.Nheko.yaml
+++ b/io.github.NhekoReborn.Nheko.yaml
@@ -14,8 +14,7 @@ finish-args:
   - --socket=x11
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.StatusNotifierItem
-  - --talk-name=org.kde.*
+  - --talk-name=org.kde.StatusNotifierWatcher
   # needed for SingleApplication to work
   - --allow=per-app-dev-shm
 cleanup:


### PR DESCRIPTION
These are the only permissions needed.

I don't know if this application needed anything else in `org.kde.*` but it should specify them specifically.